### PR TITLE
Fix Classes for UI Change

### DIFF
--- a/kattis.js
+++ b/kattis.js
@@ -103,24 +103,24 @@ const drawProblem = (hints, problem) => {
   </details>
   ` : "Not Available"
   const tableCategory = `
-    <div class="metadata_list-item">
-      <span class="metadata_list-label">Category</span>
-      <span>
+    <div class="card">
+      <div class="flex flex-col gap-3">
+        <span class="info_label">Category</span>
         ${category}
-      </span>
+      </div>
     </div>
   `
   const tableFullHint = `
-    <div class="metadata_list-item">
-      <span class="metadata_list-label">Hint</span>
-      <span style="max-width: 70%; text-align: right;">
-      ${fullHint}
-      </span>
+    <div class="card">
+      <div class="flex flex-col gap-3">
+        <span class="info_label">Hint</span>
+        ${fullHint}
+      </div>
     </div>
   `
 
-  insertAfter(document.querySelector("#editor-container .metadata_list > .metadata_list-item:last-child"), toDOM(tableCategory))
-  insertAfter(document.querySelector("#editor-container .metadata_list > .metadata_list-item:last-child"), toDOM(tableFullHint))
+  insertAfter(document.querySelector("#editor-container #metadata-tab > div:last-child"), toDOM(tableCategory))
+  insertAfter(document.querySelector("#editor-container #metadata-tab > div:last-child"), toDOM(tableFullHint))
 }
 
 const drawHints = (hints) => {

--- a/kattis.js
+++ b/kattis.js
@@ -73,12 +73,9 @@ const requestHintUpdate = () => {
 
 const drawListing = (hints) => {
   console.log("Drawing on listing")
-  const tableHeader = `
-  <th class="table-item-autofit">
-    <a href="#">Category</a>
-  </th>
-  `
-  insertAfter(document.querySelector(".table2 > thead > tr :nth-last-child(3)"), toDOM(tableHeader))
+  const tableHeader = `<th>Category</th>`
+
+  insertAfter(document.querySelector("section .table2 > thead > tr > th:nth-last-child(3)"), toDOM(tableHeader))
 
   document.querySelectorAll(".table2 > tbody > tr").forEach((row) => {
     const problem = row.querySelector("td:nth-of-type(1) > a").getAttribute("href").split("/")[2];

--- a/kattis.js
+++ b/kattis.js
@@ -106,7 +106,9 @@ const drawProblem = (hints, problem) => {
     <div class="card">
       <div class="flex flex-col gap-3">
         <span class="info_label">Category</span>
+        <span class="flex gap-3">
         ${category}
+        </span>
       </div>
     </div>
   `
@@ -114,7 +116,9 @@ const drawProblem = (hints, problem) => {
     <div class="card">
       <div class="flex flex-col gap-3">
         <span class="info_label">Hint</span>
+        <span class="flex gap-3">
         ${fullHint}
+        </span>
       </div>
     </div>
   `


### PR DESCRIPTION
They use cards in the metadata tab now. I changed the classes to match the cards and placed the category and hint cards outside of the main grid as the cards in the grid are too narrow for long hints :)

![image](https://github.com/user-attachments/assets/abbb44e2-72fd-480f-9def-3b15ae3511b2)
